### PR TITLE
Fix ReadModelConsumer delegate signature

### DIFF
--- a/src/ServiceStack.EventStore/Consumers/ReadModelConsumer.cs
+++ b/src/ServiceStack.EventStore/Consumers/ReadModelConsumer.cs
@@ -39,7 +39,7 @@ namespace ServiceStack.EventStore.Consumers
         private void LiveProcessingStarted(EventStoreCatchUpSubscription eventStoreCatchUpSubscription) => 
             log.Info("Read model now caught-up");
 
-        private async void EventAppeared(EventStoreCatchUpSubscription eventStoreCatchUpSubscription, ResolvedEvent resolvedEvent) => 
+        private async Task EventAppeared(EventStoreCatchUpSubscription eventStoreCatchUpSubscription, ResolvedEvent resolvedEvent) =>
             await Dispatch(resolvedEvent);
     }
 }


### PR DESCRIPTION
## Summary
- fix incorrect async void signature in `ReadModelConsumer.EventAppeared`

## Testing
- `dotnet test src/ServiceStack.EventStore.sln --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68420cc3433c833385f9eab557bc8932