### PR TITLE
Fix typo in GuidUtility documentation

### DIFF
--- a/src/ServiceStack.EventStore/Idempotency/GuidUtility.cs
+++ b/src/ServiceStack.EventStore/Idempotency/GuidUtility.cs
@@ -45,7 +45,7 @@ namespace ServiceStack.EventStore.Idempotency
             var namespaceBytes = namespaceId.ToByteArray();
             SwapByteOrder(namespaceBytes);
 
-            // comput the hash of the name space ID concatenated with the name (step 4)
+            // compute the hash of the namespace ID concatenated with the name (step 4)
             byte[] hash;
             using (var algorithm = version == 3 ? (HashAlgorithm)MD5.Create() : SHA1.Create())
             {


### PR DESCRIPTION
## Summary
- fix the comment describing the hash computation in `GuidUtility`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68420de1b6d4833388a6be9fe2836f84