### PR TITLE
Fix typo in TaskExtensions comment

### DIFF
--- a/src/ServiceStack.EventStore/Extensions/TaskExtensions.cs
+++ b/src/ServiceStack.EventStore/Extensions/TaskExtensions.cs
@@ -10,7 +10,7 @@ namespace ServiceStack.EventStore.Extensions
     /// </summary>
     internal static class TaskExtensions
     {
-        //Represents a succesfully completed Task
+        //Represents a successfully completed Task
         public static readonly Task CompletedTask = Task.FromResult(false);
     }
 }


### PR DESCRIPTION
## Summary
- fix spelling of "successfully" in `TaskExtensions`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68420df7b15c83338e17e5bbdc1c2221